### PR TITLE
release/early_v0.99.0

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -2,7 +2,7 @@ name: .NET
 
 on:
   push:
-    branches: [ main, dev, dev/*, feature/*, fix/*, release/* ]
+    branches: [ main, dev, feature/*, fix/*, release/* ]
 
   pull_request:
     branches: [ main ]
@@ -21,7 +21,9 @@ jobs:
     - name: Setup .NET
       uses: actions/setup-dotnet@v3
       with:
-        dotnet-version: '6.0.x'
+        dotnet-version: |
+            6.0.x
+            7.0.x
 
     # Create Local NuGet Source
 
@@ -31,33 +33,33 @@ jobs:
     - name: Add Local Nuget Source
       run: dotnet nuget add source ~/nuget
 
-    # Collections.EqualityComparers
+    # EqualityComparers
 
-    - name: Restore Collections.EqualityComparers
-      run: dotnet restore ./src/*/*/Collections.EqualityComparers.csproj
+    - name: Restore EqualityComparers
+      run: dotnet restore ./src/*/*/Collections.Generic.EqualityComparers.csproj
 
-    - name: Build Collections.EqualityComparers
-      run: dotnet build ./src/*/*/Collections.EqualityComparers.csproj --no-restore  -c Release
+    - name: Build EqualityComparers
+      run: dotnet build ./src/*/*/Collections.Generic.EqualityComparers.csproj --no-restore  -c Release
 
-    - name: Pack Collections.EqualityComparers
-      run: dotnet pack ./src/*/*/Collections.EqualityComparers.csproj --no-restore -o ~/nuget  -c Release
+    - name: Pack EqualityComparers
+      run: dotnet pack ./src/*/*/Collections.Generic.EqualityComparers.csproj --no-restore -o ~/nuget  -c Release
 
-    - name: Restore Collections.EqualityComparers.Tests
-      run: dotnet restore ./src/*/*/Collections.EqualityComparers.Tests.csproj
+    - name: Restore EqualityComparers.Tests
+      run: dotnet restore ./src/*/*/Collections.Generic.EqualityComparers.Tests.csproj
 
-    - name: Test Collections.EqualityComparers.Tests
-      run: dotnet test ./src/*/*/Collections.EqualityComparers.Tests.csproj --no-restore  -c Release
+    - name: Test EqualityComparers.Tests
+      run: dotnet test ./src/*/*/Collections.Generic.EqualityComparers.Tests.csproj --no-restore  -c Release
 
     # Collections
 
     - name: Restore Collections
-      run: dotnet restore ./src/*/*/Collections.csproj
+      run: dotnet restore ./src/*/*/Collections.Generic.csproj
 
     - name: Build Collections
-      run: dotnet build ./src/*/*/Collections.csproj --no-restore  -c Release
+      run: dotnet build ./src/*/*/Collections.Generic.csproj --no-restore  -c Release
 
     - name: Pack Collections
-      run: dotnet pack ./src/*/*/Collections.csproj --no-restore -o ~/nuget  -c Release
+      run: dotnet pack ./src/*/*/Collections.Generic.csproj --no-restore -o ~/nuget  -c Release
 
       # Push
 

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2022 Andrei Sergeev, Pavel Moskovoy
+Copyright (c) 2022-2023 Andrei Sergeev, Pavel Moskovoy
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -1,5 +1,3 @@
-# PrimeFuncPack Collections
+# PrimeFuncPack Generic Collections
 
-PrimeFuncPack Collections is a core library pack for .NET consisting of useful collection extensions:
-- Collection equality comparers (implementing value equality);
-- Immutable FlatArray.
+PrimeFuncPack Generic Collections is a core library pack for .NET consisting of collection extensions such as collection value equality comparers.

--- a/docs/collections-equality-comparers/README.md
+++ b/docs/collections-equality-comparers/README.md
@@ -1,4 +1,4 @@
-# PrimeFuncPack Collections.EqualityComparers
+# PrimeFuncPack Generic Collections.EqualityComparers
 
-PrimeFuncPack Collections.EqualityComparers is a core library for .NET consisting of collection equality comparers (implementing value equality).
-The Collections.EqualityComparers is shipped as a part of PrimeFuncPack Collections pack.
+PrimeFuncPack Generic Collections.EqualityComparers is a core library for .NET consisting of collection value equality comparers.
+The Generic Collections.EqualityComparers is shipped as a part of PrimeFuncPack Generic Collections pack.

--- a/docs/collections-flat-array/README.md
+++ b/docs/collections-flat-array/README.md
@@ -1,4 +1,0 @@
-# PrimeFuncPack Collections.FlatArray
-
-PrimeFuncPack Collections.FlatArray is a core library for .NET consisting of immutable FlatArray.
-The Collections.FlatArray is shipped as a part of PrimeFuncPack Collections pack.

--- a/docs/collections/README.md
+++ b/docs/collections/README.md
@@ -1,5 +1,3 @@
-# PrimeFuncPack Collections
+# PrimeFuncPack Generic Collections
 
-PrimeFuncPack Collections is a core library pack for .NET consisting of useful collection extensions:
-- Collection equality comparers (implementing value equality);
-- Immutable FlatArray.
+PrimeFuncPack Generic Collections is a core library pack for .NET consisting of collection extensions such as collection value equality comparers.

--- a/src/collections-generic-equalitycomparers/Collections.Generic.EqualityComparers.Tests/Collections.Generic.EqualityComparers.Tests.csproj
+++ b/src/collections-generic-equalitycomparers/Collections.Generic.EqualityComparers.Tests/Collections.Generic.EqualityComparers.Tests.csproj
@@ -1,20 +1,20 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFrameworks>net6.0;net7.0</TargetFrameworks>
     <ImplicitUsings>disable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <InvariantGlobalization>true</InvariantGlobalization>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <IsPackable>false</IsPackable>
     <Authors>Andrei Sergeev, Pavel Moskovoy</Authors>
-    <Copyright>Copyright © 2022 Andrei Sergeev, Pavel Moskovoy</Copyright>
-    <RootNamespace>PrimeFuncPack.Collections.EqualityComparers.Tests</RootNamespace>
-    <AssemblyName>PrimeFuncPack.Collections.EqualityComparers.Tests</AssemblyName>
+    <Copyright>Copyright © 2022-2023 Andrei Sergeev, Pavel Moskovoy</Copyright>
+    <RootNamespace>PrimeFuncPack.Collections.Generic.EqualityComparers.Tests</RootNamespace>
+    <AssemblyName>PrimeFuncPack.Collections.Generic.EqualityComparers.Tests</AssemblyName>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
     <PackageReference Include="xunit" Version="2.4.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
@@ -27,7 +27,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\Collections.EqualityComparers\Collections.EqualityComparers.csproj" />
+    <ProjectReference Include="..\Collections.Generic.EqualityComparers\Collections.Generic.EqualityComparers.csproj" />
   </ItemGroup>
 
 </Project>

--- a/src/collections-generic-equalitycomparers/Collections.Generic.EqualityComparers/Collections.Generic.EqualityComparers.csproj
+++ b/src/collections-generic-equalitycomparers/Collections.Generic.EqualityComparers/Collections.Generic.EqualityComparers.csproj
@@ -17,7 +17,7 @@
     <Description>PrimeFuncPack Generic Collections.EqualityComparers is a core library for .NET consisting of collection value equality comparers.</Description>
     <RootNamespace>System.Collections.Generic</RootNamespace>
     <AssemblyName>EarlyFuncPack.Collections.Generic.EqualityComparers</AssemblyName>
-    <Version>0.12.0</Version>
+    <Version>0.99.0</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/collections-generic-equalitycomparers/Collections.Generic.EqualityComparers/Collections.Generic.EqualityComparers.csproj
+++ b/src/collections-generic-equalitycomparers/Collections.Generic.EqualityComparers/Collections.Generic.EqualityComparers.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFrameworks>net6.0;net7.0</TargetFrameworks>
     <ImplicitUsings>disable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <InvariantGlobalization>true</InvariantGlobalization>
@@ -9,15 +9,15 @@
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
     <PackageLicenseFile>LICENSE</PackageLicenseFile>
     <PackageReadmeFile>README.md</PackageReadmeFile>
-    <PackageProjectUrl>https://github.com/pfpack/pfpack-collections</PackageProjectUrl>
-    <RepositoryUrl>https://github.com/pfpack/pfpack-collections</RepositoryUrl>
+    <PackageProjectUrl>https://github.com/pfpack/pfpack-collections-generic</PackageProjectUrl>
+    <RepositoryUrl>https://github.com/pfpack/pfpack-collections-generic</RepositoryUrl>
     <Company>pfpack</Company>
     <Authors>Andrei Sergeev, Pavel Moskovoy</Authors>
-    <Copyright>Copyright © 2022 Andrei Sergeev, Pavel Moskovoy</Copyright>
-    <Description>PrimeFuncPack Collections is a core library pack for .NET consisting of useful collection extensions such as collection equality comparers and immutable FlatArray.</Description>
+    <Copyright>Copyright © 2022-2023 Andrei Sergeev, Pavel Moskovoy</Copyright>
+    <Description>PrimeFuncPack Generic Collections.EqualityComparers is a core library for .NET consisting of collection value equality comparers.</Description>
     <RootNamespace>System.Collections.Generic</RootNamespace>
-    <AssemblyName>EarlyFuncPack.Collections</AssemblyName>
-    <Version>0.11.0</Version>
+    <AssemblyName>EarlyFuncPack.Collections.Generic.EqualityComparers</AssemblyName>
+    <Version>0.12.0</Version>
   </PropertyGroup>
 
   <ItemGroup>
@@ -25,14 +25,10 @@
       <Pack>True</Pack>
       <PackagePath></PackagePath>
     </None>
-    <None Include="..\..\..\docs\collections\README.md">
+    <None Include="..\..\..\docs\collections-equality-comparers\README.md">
       <Pack>True</Pack>
       <PackagePath></PackagePath>
     </None>
-  </ItemGroup>
-
-  <ItemGroup>
-    <PackageReference Include="EarlyFuncPack.Collections.EqualityComparers" Version="0.4.1" />
   </ItemGroup>
 
 </Project>

--- a/src/collections-generic-equalitycomparers/Collections.Generic.EqualityComparers/EqualityComparers/ArrayEqualityComparer.cs
+++ b/src/collections-generic-equalitycomparers/Collections.Generic.EqualityComparers/EqualityComparers/ArrayEqualityComparer.cs
@@ -51,8 +51,7 @@ public sealed class ArrayEqualityComparer<T> : IEqualityComparer<T[]>
 
     public int GetHashCode(T[] obj)
     {
-        // Return zero instead of throwing ArgumentNullException
-        if (obj is null)
+        if (obj is null) // Return zero instead of throwing ArgumentNullException
         {
             return default;
         }

--- a/src/collections-generic-equalitycomparers/Collections.Generic.EqualityComparers/EqualityComparers/ArrayEqualityComparer.cs
+++ b/src/collections-generic-equalitycomparers/Collections.Generic.EqualityComparers/EqualityComparers/ArrayEqualityComparer.cs
@@ -49,7 +49,7 @@ public sealed class ArrayEqualityComparer<T> : IEqualityComparer<T[]>
         return true;
     }
 
-    public int GetHashCode(T[] obj)
+    public int GetHashCode(T[]? obj)
     {
         if (obj is null) // Return zero instead of throwing ArgumentNullException
         {

--- a/src/collections-generic-equalitycomparers/Collections.Generic.EqualityComparers/EqualityComparers/ImmutableArrayEqualityComparer.cs
+++ b/src/collections-generic-equalitycomparers/Collections.Generic.EqualityComparers/EqualityComparers/ImmutableArrayEqualityComparer.cs
@@ -1,6 +1,6 @@
-﻿using System.Collections.Generic;
+﻿using System.Collections.Immutable;
 
-namespace System.Collections.Immutable;
+namespace System.Collections.Generic;
 
 public sealed class ImmutableArrayEqualityComparer<T> : IEqualityComparer<ImmutableArray<T>>
 {
@@ -24,15 +24,7 @@ public sealed class ImmutableArrayEqualityComparer<T> : IEqualityComparer<Immuta
 
     public bool Equals(ImmutableArray<T> x, ImmutableArray<T> y)
     {
-        // ImmutableArray 'reference' equality
-        if (x.Equals(y))
-        {
-            return true;
-        }
-
-        // Redundant since the 'reference' equality check is already done
-        // Keep for safety purposes to avoid possible NullReferenceException
-        if (x.IsDefault && y.IsDefault)
+        if (x.Equals(y)) // Check if the values' underlying arrays are reference equal
         {
             return true;
         }
@@ -60,9 +52,8 @@ public sealed class ImmutableArrayEqualityComparer<T> : IEqualityComparer<Immuta
     }
 
     public int GetHashCode(ImmutableArray<T> obj)
-    {
-        // Return zero instead of throwing ArgumentNullException
-        if (obj.IsDefault)
+    {        
+        if (obj.IsDefault) // Return zero instead of throwing ArgumentNullException
         {
             return default;
         }

--- a/src/collections-generic-equalitycomparers/Collections.Generic.EqualityComparers/EqualityComparers/ImmutableArrayEqualityComparer.cs
+++ b/src/collections-generic-equalitycomparers/Collections.Generic.EqualityComparers/EqualityComparers/ImmutableArrayEqualityComparer.cs
@@ -24,12 +24,12 @@ public sealed class ImmutableArrayEqualityComparer<T> : IEqualityComparer<Immuta
 
     public bool Equals(ImmutableArray<T> x, ImmutableArray<T> y)
     {
-        if (x.Equals(y)) // Check if the values' underlying arrays are reference equal
+        if (x.Equals(y)) // Check if the values' underlying arrays are reference equal (incl. the null case)
         {
             return true;
         }
 
-        if (x.IsDefault || y.IsDefault)
+        if (x.IsDefault || y.IsDefault) // The default means null
         {
             return false;
         }
@@ -71,11 +71,11 @@ public sealed class ImmutableArrayEqualityComparer<T> : IEqualityComparer<Immuta
 
     public bool Equals(ImmutableArray<T>? x, ImmutableArray<T>? y)
         =>
-        Equals(x.GetValueOrDefault(), y.GetValueOrDefault());
+        Equals(x.GetValueOrDefault(), y.GetValueOrDefault()); // The default means null
 
     public int GetHashCode(ImmutableArray<T>? obj)
         =>
-        GetHashCode(obj.GetValueOrDefault());
+        GetHashCode(obj.GetValueOrDefault()); // The default means null
 
     private static class InnerDefault
     {

--- a/src/collections-generic-equalitycomparers/Collections.Generic.EqualityComparers/EqualityComparers/ImmutableArrayEqualityComparer.cs
+++ b/src/collections-generic-equalitycomparers/Collections.Generic.EqualityComparers/EqualityComparers/ImmutableArrayEqualityComparer.cs
@@ -71,11 +71,11 @@ public sealed class ImmutableArrayEqualityComparer<T> : IEqualityComparer<Immuta
 
     public bool Equals(ImmutableArray<T>? x, ImmutableArray<T>? y)
         =>
-        Equals(x.GetValueOrDefault(), y.GetValueOrDefault()); // The default means null
+        Equals(x ?? default, y ?? default); // The default means null
 
     public int GetHashCode(ImmutableArray<T>? obj)
         =>
-        GetHashCode(obj.GetValueOrDefault()); // The default means null
+        GetHashCode(obj ?? default); // The default means null
 
     private static class InnerDefault
     {

--- a/src/collections-generic-equalitycomparers/Collections.Generic.EqualityComparers/EqualityComparers/ImmutableArrayEqualityComparer.cs
+++ b/src/collections-generic-equalitycomparers/Collections.Generic.EqualityComparers/EqualityComparers/ImmutableArrayEqualityComparer.cs
@@ -2,7 +2,7 @@
 
 namespace System.Collections.Generic;
 
-public sealed class ImmutableArrayEqualityComparer<T> : IEqualityComparer<ImmutableArray<T>>
+public sealed class ImmutableArrayEqualityComparer<T> : IEqualityComparer<ImmutableArray<T>>, IEqualityComparer<ImmutableArray<T>?>
 {
     private readonly IEqualityComparer<T> comparer;
 
@@ -52,7 +52,7 @@ public sealed class ImmutableArrayEqualityComparer<T> : IEqualityComparer<Immuta
     }
 
     public int GetHashCode(ImmutableArray<T> obj)
-    {        
+    {
         if (obj.IsDefault) // Return zero instead of throwing ArgumentNullException
         {
             return default;
@@ -68,6 +68,14 @@ public sealed class ImmutableArrayEqualityComparer<T> : IEqualityComparer<Immuta
 
         return builder.ToHashCode();
     }
+
+    public bool Equals(ImmutableArray<T>? x, ImmutableArray<T>? y)
+        =>
+        Equals(x.GetValueOrDefault(), y.GetValueOrDefault());
+
+    public int GetHashCode(ImmutableArray<T>? obj)
+        =>
+        GetHashCode(obj.GetValueOrDefault());
 
     private static class InnerDefault
     {

--- a/src/collections-generic-equalitycomparers/Collections.Generic.EqualityComparers/EqualityComparers/ListEqualityComparer.cs
+++ b/src/collections-generic-equalitycomparers/Collections.Generic.EqualityComparers/EqualityComparers/ListEqualityComparer.cs
@@ -26,7 +26,7 @@ public sealed class ListEqualityComparer<T> : IEqualityComparer<IList<T>>, IEqua
         =>
         InnerEquals(x, y);
 
-    public int GetHashCode(IList<T> obj)
+    public int GetHashCode(IList<T>? obj)
         =>
         InnerGetHashCode(obj);
 
@@ -34,7 +34,7 @@ public sealed class ListEqualityComparer<T> : IEqualityComparer<IList<T>>, IEqua
         =>
         InnerEquals(x, y);
 
-    public int GetHashCode(List<T> obj)
+    public int GetHashCode(List<T>? obj)
         =>
         InnerGetHashCode(obj);
 
@@ -69,7 +69,7 @@ public sealed class ListEqualityComparer<T> : IEqualityComparer<IList<T>>, IEqua
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private int InnerGetHashCode(IList<T> obj)
+    private int InnerGetHashCode(IList<T>? obj)
     {
         if (obj is null) // Return zero instead of throwing ArgumentNullException
         {

--- a/src/collections-generic-equalitycomparers/Collections.Generic.EqualityComparers/EqualityComparers/ListEqualityComparer.cs
+++ b/src/collections-generic-equalitycomparers/Collections.Generic.EqualityComparers/EqualityComparers/ListEqualityComparer.cs
@@ -71,8 +71,7 @@ public sealed class ListEqualityComparer<T> : IEqualityComparer<IList<T>>, IEqua
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private int InnerGetHashCode(IList<T> obj)
     {
-        // Return zero instead of throwing ArgumentNullException
-        if (obj is null)
+        if (obj is null) // Return zero instead of throwing ArgumentNullException
         {
             return default;
         }

--- a/src/collections-generic-equalitycomparers/Collections.Generic.EqualityComparers/EqualityComparers/ListEqualityComparer.cs
+++ b/src/collections-generic-equalitycomparers/Collections.Generic.EqualityComparers/EqualityComparers/ListEqualityComparer.cs
@@ -1,6 +1,4 @@
-﻿using System.Runtime.CompilerServices;
-
-namespace System.Collections.Generic;
+﻿namespace System.Collections.Generic;
 
 public sealed class ListEqualityComparer<T> : IEqualityComparer<IList<T>>, IEqualityComparer<List<T>>
 {
@@ -23,23 +21,6 @@ public sealed class ListEqualityComparer<T> : IEqualityComparer<IList<T>>, IEqua
         InnerDefault.Value;
 
     public bool Equals(IList<T>? x, IList<T>? y)
-        =>
-        InnerEquals(x, y);
-
-    public int GetHashCode(IList<T>? obj)
-        =>
-        InnerGetHashCode(obj);
-
-    public bool Equals(List<T>? x, List<T>? y)
-        =>
-        InnerEquals(x, y);
-
-    public int GetHashCode(List<T>? obj)
-        =>
-        InnerGetHashCode(obj);
-
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private bool InnerEquals(IList<T>? x, IList<T>? y)
     {
         if (ReferenceEquals(x, y))
         {
@@ -68,8 +49,7 @@ public sealed class ListEqualityComparer<T> : IEqualityComparer<IList<T>>, IEqua
         return true;
     }
 
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private int InnerGetHashCode(IList<T>? obj)
+    public int GetHashCode(IList<T>? obj)
     {
         if (obj is null) // Return zero instead of throwing ArgumentNullException
         {
@@ -86,6 +66,14 @@ public sealed class ListEqualityComparer<T> : IEqualityComparer<IList<T>>, IEqua
 
         return builder.ToHashCode();
     }
+
+    public bool Equals(List<T>? x, List<T>? y)
+        =>
+        Equals((IList<T>?)x, y);
+
+    public int GetHashCode(List<T>? obj)
+        =>
+        GetHashCode((IList<T>?)obj);
 
     private static class InnerDefault
     {

--- a/src/collections-generic-equalitycomparers/Collections.Generic.EqualityComparers/EqualityComparers/ListEqualityComparer.cs
+++ b/src/collections-generic-equalitycomparers/Collections.Generic.EqualityComparers/EqualityComparers/ListEqualityComparer.cs
@@ -26,13 +26,13 @@ public sealed class ListEqualityComparer<T> : IEqualityComparer<IList<T>>, IEqua
         =>
         InnerEquals(x, y);
 
-    public bool Equals(List<T>? x, List<T>? y)
-        =>
-        InnerEquals(x, y);
-
     public int GetHashCode(IList<T> obj)
         =>
         InnerGetHashCode(obj);
+
+    public bool Equals(List<T>? x, List<T>? y)
+        =>
+        InnerEquals(x, y);
 
     public int GetHashCode(List<T> obj)
         =>

--- a/src/collections-generic-equalitycomparers/Collections.Generic.EqualityComparers/EqualityComparers/ReadOnlyListEqualityComparer.cs
+++ b/src/collections-generic-equalitycomparers/Collections.Generic.EqualityComparers/EqualityComparers/ReadOnlyListEqualityComparer.cs
@@ -49,7 +49,7 @@ public sealed class ReadOnlyListEqualityComparer<T> : IEqualityComparer<IReadOnl
         return true;
     }
 
-    public int GetHashCode(IReadOnlyList<T> obj)
+    public int GetHashCode(IReadOnlyList<T>? obj)
     {
         if (obj is null) // Return zero instead of throwing ArgumentNullException
         {

--- a/src/collections-generic-equalitycomparers/Collections.Generic.EqualityComparers/EqualityComparers/ReadOnlyListEqualityComparer.cs
+++ b/src/collections-generic-equalitycomparers/Collections.Generic.EqualityComparers/EqualityComparers/ReadOnlyListEqualityComparer.cs
@@ -51,8 +51,7 @@ public sealed class ReadOnlyListEqualityComparer<T> : IEqualityComparer<IReadOnl
 
     public int GetHashCode(IReadOnlyList<T> obj)
     {
-        // Return zero instead of throwing ArgumentNullException
-        if (obj is null)
+        if (obj is null) // Return zero instead of throwing ArgumentNullException
         {
             return default;
         }

--- a/src/collections-generic/Collections.Generic/Collections.Generic.csproj
+++ b/src/collections-generic/Collections.Generic/Collections.Generic.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFrameworks>net6.0;net7.0</TargetFrameworks>
     <ImplicitUsings>disable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <InvariantGlobalization>true</InvariantGlobalization>
@@ -9,15 +9,15 @@
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
     <PackageLicenseFile>LICENSE</PackageLicenseFile>
     <PackageReadmeFile>README.md</PackageReadmeFile>
-    <PackageProjectUrl>https://github.com/pfpack/pfpack-collections</PackageProjectUrl>
-    <RepositoryUrl>https://github.com/pfpack/pfpack-collections</RepositoryUrl>
+    <PackageProjectUrl>https://github.com/pfpack/pfpack-collections-generic</PackageProjectUrl>
+    <RepositoryUrl>https://github.com/pfpack/pfpack-collections-generic</RepositoryUrl>
     <Company>pfpack</Company>
     <Authors>Andrei Sergeev, Pavel Moskovoy</Authors>
-    <Copyright>Copyright © 2022 Andrei Sergeev, Pavel Moskovoy</Copyright>
-    <Description>PrimeFuncPack Collections.EqualityComparers is a core library for .NET consisting of collection equality comparers (implementing value equality).</Description>
+    <Copyright>Copyright © 2022-2023 Andrei Sergeev, Pavel Moskovoy</Copyright>
+    <Description>PrimeFuncPack Generic Collections is a core library pack for .NET consisting of collection extensions such as collection value equality comparers.</Description>
     <RootNamespace>System.Collections.Generic</RootNamespace>
-    <AssemblyName>EarlyFuncPack.Collections.EqualityComparers</AssemblyName>
-    <Version>0.4.1</Version>
+    <AssemblyName>EarlyFuncPack.Collections.Generic</AssemblyName>
+    <Version>0.12.0</Version>
   </PropertyGroup>
 
   <ItemGroup>
@@ -25,10 +25,14 @@
       <Pack>True</Pack>
       <PackagePath></PackagePath>
     </None>
-    <None Include="..\..\..\docs\collections-equality-comparers\README.md">
+    <None Include="..\..\..\docs\collections\README.md">
       <Pack>True</Pack>
       <PackagePath></PackagePath>
     </None>
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="EarlyFuncPack.Collections.Generic.EqualityComparers" Version="0.12.0" />
   </ItemGroup>
 
 </Project>

--- a/src/collections-generic/Collections.Generic/Collections.Generic.csproj
+++ b/src/collections-generic/Collections.Generic/Collections.Generic.csproj
@@ -17,7 +17,7 @@
     <Description>PrimeFuncPack Generic Collections is a core library pack for .NET consisting of collection extensions such as collection value equality comparers.</Description>
     <RootNamespace>System.Collections.Generic</RootNamespace>
     <AssemblyName>EarlyFuncPack.Collections.Generic</AssemblyName>
-    <Version>0.12.0</Version>
+    <Version>0.99.0</Version>
   </PropertyGroup>
 
   <ItemGroup>
@@ -32,7 +32,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="EarlyFuncPack.Collections.Generic.EqualityComparers" Version="0.12.0" />
+    <PackageReference Include="EarlyFuncPack.Collections.Generic.EqualityComparers" Version="0.99.0" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
 EarlyFuncPack Generic Collections v0.99.0:
- Rename packages from `EarlyFuncPack.Collections.*` to `EarlyFuncPack.Collections.Generic.*`
- Add multi-targeting (`net6.0;net7.0`)
- Improve nullability support (add `?` annotation to all the `GetHashCode`; add nullable support to `ImmutableArrayEqualityComparer`)
- Fix `ImmutableArrayEqualityComparer` namespace
- Minor refactor
- release/early_v0.99.0